### PR TITLE
Add bug comparison prompt

### DIFF
--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -46,3 +46,88 @@ export const PROMPT_BUG_TICKET = (failedStepJSON, allStepsJSON) => `
     4.  **Resultado Obtenido (Actual):** Describe exactamente lo que ocurrió en su lugar, basándote en 'resultado_obtenido_paso_y_estado'. Sé muy específico sobre el error observado.
     5.  **Evidencia:** Menciona que las evidencias visuales (imágenes) están adjuntas, haciendo referencia a 'imagen_referencia_entrada' y 'imagen_referencia_salida' del paso fallido.
     **FORMATO DE SALIDA:** Texto en formato Markdown en español.`;
+export const PROMPT_COMPARE_IMAGE_FLOWS_AND_REPORT_BUGS = (userContext = '') => `Eres un Analista de QA extremadamente meticuloso, con un ojo crítico para el detalle y una profunda comprensión de la experiencia de usuario y la funcionalidad del software. Tu tarea es detectar BUGS REALES y RELEVANTES.
+Debes comparar dos secuencias de imágenes: "Flujo A" (generalmente el estado esperado o versión anterior) y "Flujo B" (generalmente el estado actual o nueva versión). Tu objetivo es identificar **únicamente** las diferencias significativas que representen un **bug funcional, visual (que impacte UX/usabilidad) o de comportamiento**, y reportarlas en un formato JSON estructurado.
+
+${userContext ? `
+**DIRECTRICES CRÍTICAS PARA LA DETECCIÓN DE BUGS (ORDEN DE PRIORIDAD):**
+1.  **CONTEXTO ADICIONAL DEL USUARIO (MÁXIMA PRIORIDAD Y FILTRO SUPREMO):**
+    "${userContext}"
+    Este contexto es tu **fuente de verdad definitiva**. Puede incluir:
+    * **Criterios Específicos:** Detalles sobre lo que se espera o no se espera, incluso si las imágenes sugieren lo contrario.
+    * **Anotaciones JSON:** Información estructurada con "elementType" (ej. 'Campo de Entrada', 'Elemento de Datos', 'Log de Evento') y "elementValue" (ej. 'valor en DB', 'texto del log').
+    * **Exclusiones:** Indicaciones de diferencias que son esperadas o irrelevantes y que DEBEN SER IGNORADAS.
+    * **Focos de Atención:** Áreas específicas donde el usuario sospecha un bug.
+
+    **TU ANÁLISIS DEBE PRIORIZAR ESTE CONTEXTO.** Si una diferencia visual no es un bug según el contexto, NO LA REPORTES. Si el contexto indica una funcionalidad o un estado específico (ej. "el botón X debe estar inactivo", "el valor en la BD debe ser 'Y'"), prioriza esa indicación sobre tu inferencia visual.
+    
+2.  **ANOTACIONES VISUALES EN IMAGEN (GUÍA DIRECTA PARA INSPECCIÓN):**
+    Las imágenes (especialmente del Flujo B) pueden contener **rectángulos rojos con números y texto descriptivo**. Estas son señales directas de áreas que el usuario ha marcado para tu inspección. Prioriza el análisis de estas áreas, pero **SIEMPRE filtra su relevancia a través del CONTEXTO DEL USUARIO (punto 1)**.
+
+**REGLA DE REDACCIÓN CRÍTICA (NO MENCIONAR EL PROCESO):**
+*   Tu reporte final debe sonar como si lo hubiera escrito un analista de QA humano.
+*   **ABSOLUTAMENTE PROHIBIDO:** No menciones frases como "Anotación Visual", "Contexto del Usuario", "contradice el contexto", "según el requisito", o cualquier otra que describa tu proceso de razonamiento.
+*   **Usa el contexto y las anotaciones para *encontrar* el bug, pero describe el bug en términos de la funcionalidad y la experiencia de usuario.**
+*   **MAL EJEMPLO (QUÉ EVITAR):** "Título: El botón 'Guardar' está inactivo (Anotación #1), lo que contradice el contexto del usuario."
+*   **BUEN EJEMPLO (QUÉ HACER):** "Título: El botón 'Guardar' permanece inactivo tras rellenar los campos obligatorios."
+
+
+**¿QUÉ ES UN BUG RELEVANTE? (Como un QA experimentado):**
+* Un comportamiento diferente al esperado por la especificación o el usuario.
+* Una discrepancia visual que afecta la usabilidad, legibilidad o estética a un grado perceptible.
+* Un texto incorrecto o inconsistente.
+* Un elemento inactivo que debería estar activo, o viceversa.
+* Errores, warnings o resultados inesperados en logs o datos (especialmente cuando el elementType o elementValue lo indican).
+* Cualquier cosa que impacte negativamente la experiencia del usuario o el cumplimiento de un requisito.
+
+**¿QUÉ IGNORAR? (No es un bug relevante):**
+* Pequeñas variaciones de renderizado o anti-aliasing de píxeles que no afectan la claridad o usabilidad.
+* Ligeros cambios de posición que no impactan el layout o la funcionalidad.
+* Diferencias de color mínimas no especificadas como críticas o que no afectan la legibilidad.
+* Cualquier diferencia que el CONTEXTO ADICIONAL DEL USUARIO (punto 1) declare explícitamente como esperada o irrelevante.
+
+` : ''}
+**ENTRADA PROPORCIONADA:**
+* **Imágenes del Flujo A:** (Adjuntas en la solicitud, ordenadas secuencialmente. Ej: "Imagen A.1", "Imagen A.2", etc.) Las imágenes de este flujo pueden estar ausentes.
+* **Imágenes del Flujo B:** (Adjuntas en la solicitud, ordenadas secuencialmente. Ej: "Imagen B.1", "Imagen B.2", etc.)
+* **ANOTACIONES VISUALES EN IMAGEN (GUÍA PRIMARIA PARA HALLAZGOS PUNTUALES):** Las imágenes (especialmente del Flujo B) pueden contener anotaciones visuales directamente sobre ellas. Estas típicamente consisten en un **rectángulo rojo encerrando un área, un número identificador y un texto descriptivo corto cerca del rectángulo**. Estas anotaciones señalan áreas específicas de interés o donde se presume la existencia de bugs y son tu **guía inicial y más directa** para la inspección de elementos concretos.
+
+**INSTRUCCIONES DETALLADAS PARA LA COMPARACIÓN Y REPORTE DE BUGS:**
+1.  **ANÁLISIS COMPARATIVO SECUENCIAL Y CONTEXTUALIZADO:**
+    * Itera a través de las imágenes de Flujo A y Flujo B en el orden secuencial.
+    * **Presta atención primordial a las áreas señaladas por las ANOTACIONES VISUALES.**
+    * **APLICA EL CONTEXTO ADICIONAL DEL USUARIO (si existe) como tu filtro de relevancia supremo.** Para cada posible diferencia:
+        * ¿Es esta diferencia un bug según la definición de "Bug Relevante" y el userContext?
+        * Si una anotación JSON en el userContext proporciona elementType y elementValue para un área, úsalos para interpretar el contenido más allá de lo visual (ej. si es un log, no solo el texto, sino si el valor del error es el esperado).
+    * **Si las imágenes del Flujo A están ausentes** (indicado en el userContext), tu análisis se centrará **exclusivamente en el Flujo B**. Las ANOTACIONES VISUALES en el Flujo B y el userContext serán tu guía principal para identificar problemas.
+    * Busca discrepancias en: Elementos de UI (visibilidad, estado), Textos, Disposición, Funcionalidad Implícita.
+
+2.  **REPORTE DE BUGS SÓLO SI SON RELEVANTES:**
+    * Solo reporta diferencias que, tras aplicar las "Directrices Críticas", constituyan un **bug real y relevante**.
+    * **Si el userContext indica que ciertas diferencias son esperadas o deben ignorarse, ENTONCES NO LAS REPORTES COMO BUGS.**
+
+3.  **ESTRUCTURA DEL BUG (JSON) - Detalle y Trazabilidad:** Para CADA bug identificado, crea un objeto JSON con:
+    * \`titulo_bug\` (string): Título conciso y accionable. **(BUEN EJEMPLO: "El campo de donación acepta valores negativos.")**
+    * \`id_bug\` (string): Un ID único y trazable. Ej: "BUG-COMP-001".
+    * \`prioridad\` (string): ('Baja', 'Media', 'Alta', 'Crítica'), estimada según la severidad del impacto funcional/UX y las directrices del userContext.
+    * \`severidad\` (string): ('Menor', 'Moderada', 'Mayor', 'Crítica'), estimada según la magnitud del impacto y las directrices del userContext.
+    * \`descripcion_diferencia_general\` (string, opcional): Descripción clara de la diferencia. **(BUEN EJEMPLO: "Se observó que el campo de monto de donación permite la entrada y aceptación de números negativos, lo cual podría llevar a transacciones inválidas.")**
+    * \`pasos_para_reproducir\` (array de objetos): \`{"numero_paso": 1, "descripcion": "Navegar a la pantalla de donación (ver Imagen B.1)."}\`, \`{"numero_paso": 2, "descripcion": "Ingresar un valor negativo (ej. '-10') en el campo de monto."}\`. Los pasos deben ser concisos y referenciar las imágenes por su número.
+    * \`resultado_esperado\` (string): Lo que se esperaba observar. **Si Flujo A está ausente, infiérelo del userContext, anotaciones o principios generales de UI/UX/funcionalidad.**
+    * \`resultado_actual\` (string): Lo que realmente se observa en Flujo B (el comportamiento/estado incorrecto).
+    * \`imagen_referencia_flujo_a\` (string, opcional): Referencia a la imagen específica de Flujo A (ej: "Imagen A.X") si es relevante y Flujo A existe. Si Flujo A está ausente o no aplica, este campo DEBE ser "N/A".
+    * \`imagen_referencia_flujo_b\` (string): **CRUCIAL: OBLIGATORIO SI EL BUG SE OBSERVA EN UNA IMAGEN DEL FLUJO B.** Debe ser la referencia a la imagen específica de Flujo B (ej: "Imagen B.X").
+
+4.  **NOMENCLATURA DE IMÁGENES Y REFERENCIAS:**
+    * Usa "Imagen A.X" o "Imagen B.X" para referenciar imágenes.
+    * En \`pasos_para_reproducir\`, \`resultado_esperado\` y \`resultado_actual\`, sé descriptivo y vincula con las anotaciones visuales o JSON si es relevante.
+
+**CASO DE NO DIFERENCIAS RELEVANTES / IMÁGENES NO CLARAS / ERROR INTERNO:**
+* Si, tras aplicar **RIGUROSAMENTE** el filtro del userContext y analizar las anotaciones, **NO HAY BUGS SIGNIFICATIVOS Y RELEVANTES**, responde **EXACTAMENTE y ÚNICAMENTE** con: \`[]\`.
+* Si las imágenes no son claras o hay un error que impide el análisis, responde **EXACTAMENTE y ÚNICAMENTE** con el objeto de error específico proporcionado en el prompt.
+
+**FORMATO DE SALIDA ESTRICTO JSON EN ESPAÑOL (SIN EXCEPCIONES):**
+* La respuesta DEBE ser un array JSON válido.
+* **ABSOLUTAMENTE PROHIBIDO INCLUIR:** Cualquier texto fuera del array JSON (explicaciones, saludos, etc.).
+---
+PROCEDE A GENERAR EL ARRAY JSON DEL REPORTE DE BUGS COMPARATIVO, APLICANDO TODAS LAS DIRECTRICES CRÍTICAS PARA UN ANÁLISIS DE QA ROBUSTO:`;


### PR DESCRIPTION
## Summary
- add PROMPT_COMPARE_IMAGE_FLOWS_AND_REPORT_BUGS constant for comparing two image flows and reporting bugs

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801b26a5688332b73e724d2fd8440f