### PR TITLE
Add controls for scenario and bug generators

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ConfigurationPanel from './components/ConfigurationPanel';
 import ImageUploader from './components/ImageUploader';
 import ReportDisplay from './components/ReportDisplay';
@@ -12,12 +12,15 @@ import { useAppContext } from './context/AppContext';
 function App() {
     const {
         isRefining,
-        modal, 
-        closeModal, 
+        modal,
+        closeModal,
         reportRef,
         reports,
         isConfigVisible
     } = useAppContext();
+
+    const [showScenario, setShowScenario] = useState(false);
+    const [showBugs, setShowBugs] = useState(false);
 
     return (
         <div className="container mx-auto p-4 md:p-8 max-w-7xl">
@@ -26,25 +29,32 @@ function App() {
                 <p className="text-lg text-gray-600 mt-2">Analiza y refina flujos de prueba a partir de evidencias visuales.</p>
             </header>
 
-            <ConfigToggler />
+            <ConfigToggler
+                onToggleScenario={() => setShowScenario(!showScenario)}
+                onToggleBugs={() => setShowBugs(!showBugs)}
+            />
             <div className="flex flex-col gap-8 mt-16 md:mt-0">
-                {isConfigVisible && (
-                    <div className="bg-white rounded-lg shadow-md p-6 glassmorphism">
-                        <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">Configuración</h2>
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                            <ConfigurationPanel />
-                            <ImageUploader />
+                {showScenario && (
+                    <>
+                        {isConfigVisible && (
+                            <div className="bg-white rounded-lg shadow-md p-6 glassmorphism">
+                                <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">Configuración</h2>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                    <ConfigurationPanel />
+                                    <ImageUploader />
+                                </div>
+                            </div>
+                        )}
+
+                        <div ref={reportRef} className="space-y-8">
+                            <ReportTabs />
+                            <ReportDisplay />
+                            {isRefining && <RefinementControls />}
                         </div>
-                    </div>
+                    </>
                 )}
 
-                <div ref={reportRef} className="space-y-8">
-                     <ReportTabs />
-                     <ReportDisplay />
-                    {isRefining && <RefinementControls />}
-                </div>
-
-                <FlowComparison />
+                {showBugs && <FlowComparison />}
             </div>
 
             <TicketModal

--- a/src/components/ConfigToggler.jsx
+++ b/src/components/ConfigToggler.jsx
@@ -1,16 +1,30 @@
 import React from 'react';
 import { useAppContext } from '../context/AppContext';
 
-const ConfigToggler = () => {
+const ConfigToggler = ({ onToggleScenario, onToggleBugs }) => {
     const { showConfigurationPanel, setShowConfigurationPanel } = useAppContext();
 
     return (
-        <button
-            onClick={() => setShowConfigurationPanel(!showConfigurationPanel)}
-            className="fixed bottom-4 right-4 z-50 md:static bg-primary text-white font-semibold py-2 px-4 rounded-full shadow-md hover:bg-primary/90 transition-colors w-48 md:w-auto"
-        >
-            {showConfigurationPanel ? 'Ocultar Configuración' : 'Mostrar Configuración'}
-        </button>
+        <div className="fixed bottom-4 right-4 z-50 md:static flex flex-col md:flex-row gap-2">
+            <button
+                onClick={() => setShowConfigurationPanel(!showConfigurationPanel)}
+                className="bg-primary text-white font-semibold py-2 px-4 rounded-full shadow-md hover:bg-primary/90 transition-colors w-48 md:w-auto"
+            >
+                {showConfigurationPanel ? 'Ocultar Configuración' : 'Mostrar Configuración'}
+            </button>
+            <button
+                onClick={onToggleScenario}
+                className="bg-primary text-white font-semibold py-2 px-4 rounded-full shadow-md hover:bg-primary/90 transition-colors w-48 md:w-auto"
+            >
+                Generar Escenarios con imágenes
+            </button>
+            <button
+                onClick={onToggleBugs}
+                className="bg-blue-800 text-white font-semibold py-2 px-4 rounded-full shadow-md hover:bg-blue-900 transition-colors w-48 md:w-auto"
+            >
+                Generar Bugs
+            </button>
+        </div>
     );
 };
 

--- a/src/components/FlowComparison.jsx
+++ b/src/components/FlowComparison.jsx
@@ -146,14 +146,14 @@ function FlowComparison({ onComparisonGenerated }) {
                     onClick={() => setShowForm(true)}
                     className="bg-blue-800 text-white rounded font-semibold px-4 py-2"
                 >
-                    Comparar Flujos
+                    Generar Bugs
                 </button>
             )}
 
             {showForm && (
                 <div className="bg-white rounded-xl shadow-md p-6 mt-4">
                     <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">
-                        Comparación de Flujos
+                        Generar Bugs
                     </h2>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div>
@@ -265,7 +265,7 @@ function FlowComparison({ onComparisonGenerated }) {
                             onClick={handleGenerateComparison}
                             className="bg-blue-800 text-white rounded font-semibold px-4 py-2 disabled:bg-gray-400"
                         >
-                            Generar Comparación
+                            Generar Bugs
                         </button>
                     </div>
 


### PR DESCRIPTION
## Summary
- add toggles for opening scenario generator and bug generator
- show scenario/bug sections only when toggled
- rename flow comparison feature to "Generar Bugs"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68811834e8f08332b2e60aabd0d2f413