### PR TITLE
Separate configuration and scenario panels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,8 +15,7 @@ function App() {
         modal,
         closeModal,
         reportRef,
-        reports,
-        isConfigVisible
+        showConfigurationPanel
     } = useAppContext();
 
     const [showScenario, setShowScenario] = useState(false);
@@ -34,17 +33,19 @@ function App() {
                 onToggleBugs={() => setShowBugs(!showBugs)}
             />
             <div className="flex flex-col gap-8 mt-16 md:mt-0">
+                {showConfigurationPanel && (
+                    <ConfigurationPanel mode="config" />
+                )}
+
                 {showScenario && (
                     <>
-                        {isConfigVisible && (
-                            <div className="bg-white rounded-lg shadow-md p-6 glassmorphism">
-                                <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">Configuración</h2>
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                                    <ConfigurationPanel />
-                                    <ImageUploader />
-                                </div>
+                        <div className="bg-white rounded-lg shadow-md p-6 glassmorphism">
+                            <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">Generar Escenarios con imágenes</h2>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                <ImageUploader />
+                                <ConfigurationPanel mode="actions" />
                             </div>
-                        )}
+                        </div>
 
                         <div ref={reportRef} className="space-y-8">
                             <ReportTabs />

--- a/src/components/ConfigurationPanel.jsx
+++ b/src/components/ConfigurationPanel.jsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { downloadHtmlReport } from '../lib/downloadService';
 
-function ConfigurationPanel() {
-    const { showConfigurationPanel } = useAppContext();
+function ConfigurationPanel({ mode = 'full' }) {
     const {
         apiConfig,
         setApiConfig,
@@ -14,7 +13,6 @@ function ConfigurationPanel() {
         canDownload,
         activeReport,
         reports, // Get all reports
-        imageFiles,
         scrollToReport
     } = useAppContext();
 
@@ -51,10 +49,16 @@ function ConfigurationPanel() {
         scrollToReport();
     };
 
+    const showConfig = mode !== 'actions';
+    const showActions = mode !== 'config';
+
     return (
-        <div className={`bg-white rounded-xl shadow-md p-6 glassmorphism ${!showConfigurationPanel ? 'hidden' : ''}`}>
-            <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">Configuración y Acciones</h2>
-            
+        <div className="bg-white rounded-xl shadow-md p-6 glassmorphism">
+            <h2 className="text-xl font-semibold mb-4 text-gray-800 border-b pb-2">
+                {showConfig && showActions ? 'Configuración y Acciones' : showConfig ? 'Configuración' : 'Acciones'}
+            </h2>
+
+            {showConfig && (
             <div className="space-y-4">
                 <div>
                     <label htmlFor="ai-provider-select" className="block text-sm font-medium text-gray-700 mb-1">Proveedor de IA
@@ -166,8 +170,10 @@ function ConfigurationPanel() {
                     💾 Guardar Configuración
                 </button>
             </div>
+            )}
 
-            <div id="main-actions" className="mt-6 pt-4 border-t space-y-3">
+            {showActions && (
+            <div id="main-actions" className={`mt-6 space-y-3 ${showConfig ? 'pt-4 border-t' : ''}`}>
                 <button
                     onClick={() => handleAnalysis(false)}
                     disabled={!canGenerate}
@@ -208,6 +214,7 @@ function ConfigurationPanel() {
                     )}
                 </div>
             </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add `mode` prop to `ConfigurationPanel` so it can display only configuration or only actions
- adjust `App` layout to show configuration, scenario and bug sections separately

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68812352ff7883329e2c44c1453bcae5