### PR TITLE
Fix bug generator and config toggle

### DIFF
--- a/src/components/ConfigToggler.jsx
+++ b/src/components/ConfigToggler.jsx
@@ -10,7 +10,7 @@ const ConfigToggler = ({ onToggleScenario, onToggleBugs }) => {
                 onClick={() => setShowConfigurationPanel(!showConfigurationPanel)}
                 className="bg-primary text-white font-semibold py-2 px-4 rounded-full shadow-md hover:bg-primary/90 transition-colors w-48 md:w-auto"
             >
-                {showConfigurationPanel ? 'Ocultar Configuración' : 'Mostrar Configuración'}
+                Configuración
             </button>
             <button
                 onClick={onToggleScenario}

--- a/src/components/FlowComparison.jsx
+++ b/src/components/FlowComparison.jsx
@@ -16,7 +16,7 @@ function slugify(str) {
 }
 
 function FlowComparison({ onComparisonGenerated }) {
-    const [showForm, setShowForm] = useState(false);
+    const [showForm, setShowForm] = useState(true);
     const [currentFlowTitle, setCurrentFlowTitle] = useState('');
     const [currentFlowSprint, setCurrentFlowSprint] = useState('');
     const [currentGeneratedId, setCurrentGeneratedId] = useState('');


### PR DESCRIPTION
## Summary
- rename configuration toggle to always say `Configuración`
- show bug generation form immediately when opened

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688125e20270833288cf2a235182e9eb