### PR TITLE
Fix bug report flow

### DIFF
--- a/src/components/BugReport.jsx
+++ b/src/components/BugReport.jsx
@@ -123,13 +123,13 @@ function BugReport({ data, flowA = [], flowB = [], onClose }) {
                                 {imgA && (
                                     <div className="flex flex-col items-start">
                                         <span className="text-sm font-semibold mb-1 flex items-center gap-1">🖼️ Flujo A: {bug.imagen_referencia_flujo_a}</span>
-                                        <img src={imgA} alt={bug.imagen_referencia_flujo_a} className="w-32 h-auto rounded border" crossOrigin="anonymous" />
+                                        <img src={imgA} alt={bug.imagen_referencia_flujo_a} className="w-48 h-auto rounded border" crossOrigin="anonymous" />
                                     </div>
                                 )}
                                 {imgB && (
                                     <div className="flex flex-col items-start">
                                         <span className="text-sm font-semibold mb-1 flex items-center gap-1">🖼️ Flujo B: {bug.imagen_referencia_flujo_b}</span>
-                                        <img src={imgB} alt={bug.imagen_referencia_flujo_b} className="w-32 h-auto rounded border" crossOrigin="anonymous" />
+                                        <img src={imgB} alt={bug.imagen_referencia_flujo_b} className="w-48 h-auto rounded border" crossOrigin="anonymous" />
                                     </div>
                                 )}
                             </div>

--- a/src/components/BugReportTabs.jsx
+++ b/src/components/BugReportTabs.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+function BugReportTabs({ reports, activeIndex, selectReport, deleteReport, updateName }) {
+    const [editingIndex, setEditingIndex] = useState(null);
+    const [editingValue, setEditingValue] = useState('');
+    const inputRef = useRef(null);
+
+    useEffect(() => {
+        if (editingIndex !== null && inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, [editingIndex]);
+
+    const handleDoubleClick = (index, currentName) => {
+        setEditingIndex(index);
+        setEditingValue(currentName);
+    };
+
+    const handleNameChange = (e) => {
+        setEditingValue(e.target.value);
+    };
+
+    const handleSaveName = (index) => {
+        if (editingValue.trim()) {
+            updateName(index, editingValue.trim());
+        }
+        setEditingIndex(null);
+    };
+
+    const handleKeyDown = (e, index) => {
+        if (e.key === 'Enter') {
+            handleSaveName(index);
+        } else if (e.key === 'Escape') {
+            setEditingIndex(null);
+        }
+    };
+
+    if (!reports || reports.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap border-b border-gray-200">
+            {reports.map((report, index) => (
+                <div
+                    key={index}
+                    className={`flex items-center py-2 px-4 cursor-pointer border-b-2 ${
+                        activeIndex === index
+                            ? 'border-blue-800 text-blue-800'
+                            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    }`}
+                    onClick={() => selectReport(index)}
+                >
+                    {editingIndex === index ? (
+                        <input
+                            ref={inputRef}
+                            type="text"
+                            value={editingValue}
+                            onChange={handleNameChange}
+                            onBlur={() => handleSaveName(index)}
+                            onKeyDown={(e) => handleKeyDown(e, index)}
+                            className="bg-transparent border-none focus:ring-0 p-0"
+                        />
+                    ) : (
+                        <span onDoubleClick={() => handleDoubleClick(index, report.title || `Bug ${index + 1}`)}>
+                            {report.title || `Bug ${index + 1}`}
+                        </span>
+                    )}
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            deleteReport(index);
+                        }}
+                        className="ml-2 text-gray-400 hover:text-gray-600"
+                    >
+                        &times;
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default BugReportTabs;


### PR DESCRIPTION
## Summary
- adjust bug report images for better PDF size
- add bug report tabs for navigation
- persist generated bug reports in localStorage
- allow setting a user context for bug analysis
- show loading indicator while generating bug report

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68812de5f04483329de4aab5c9d1bb65