### PR TITLE
Fix bug report storage issues

### DIFF
--- a/src/components/BugReport.jsx
+++ b/src/components/BugReport.jsx
@@ -6,7 +6,7 @@ function BugReport({ data, flowA = [], flowB = [] }) {
 
     const getImageUrl = (ref) => {
         if (!ref || typeof ref !== 'string') return null;
-        const match = ref.match(/imagen\s+([ab])[:\.\s]*?(\d+)/i);
+        const match = ref.match(/([ab])[^0-9]*(\d+)/i);
         if (!match) return null;
         const flow = match[1].toUpperCase();
         const idx = parseInt(match[2], 10) - 1;

--- a/src/components/FlowComparison.jsx
+++ b/src/components/FlowComparison.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { callAiApi } from '../lib/apiService';
 import { PROMPT_COMPARE_IMAGE_FLOWS_AND_REPORT_BUGS } from '../lib/prompts';
 import { useAppContext } from '../context/AppContext';
+import { loadBugReports, saveBugReports } from '../lib/idbService';
 import BugReport from './BugReport';
 import BugReportTabs from './BugReportTabs';
 import FlowImageUploader from './FlowImageUploader';
@@ -25,14 +26,21 @@ function FlowComparison({ onComparisonGenerated }) {
     const [loading, setLoading] = useState(false);
     const [userContext, setUserContext] = useState('');
 
-    const [bugReports, setBugReports] = useState(() => {
-        const cached = localStorage.getItem('qaBugReports');
-        return cached ? JSON.parse(cached) : [];
-    });
+    const [bugReports, setBugReports] = useState([]);
     const [activeReportIndex, setActiveReportIndex] = useState(0);
 
     useEffect(() => {
-        localStorage.setItem('qaBugReports', JSON.stringify(bugReports));
+        loadBugReports()
+            .then((cached) => {
+                if (cached && cached.length > 0) {
+                    setBugReports(cached);
+                }
+            })
+            .catch((err) => console.error('Error al cargar bugReports', err));
+    }, []);
+
+    useEffect(() => {
+        saveBugReports(bugReports).catch((err) => console.error('Error al guardar bugReports', err));
     }, [bugReports]);
 
     const resetForm = () => {


### PR DESCRIPTION
## Summary
- store bug reports using IndexedDB to avoid localStorage quota errors
- make image references more flexible so screenshots load correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881354321508332a6b722f9b890a6c7