### PR TITLE
Fix bug report image references

### DIFF
--- a/src/components/BugReport.jsx
+++ b/src/components/BugReport.jsx
@@ -6,7 +6,7 @@ function BugReport({ data, flowA = [], flowB = [] }) {
 
     const getImageUrl = (ref) => {
         if (!ref || typeof ref !== 'string') return null;
-        const match = ref.match(/([ab])[^0-9]*(\d+)/i);
+        const match = ref.match(/\b([ab])[^0-9]*(\d+)/i);
         if (!match) return null;
         const flow = match[1].toUpperCase();
         const num = parseInt(match[2], 10);


### PR DESCRIPTION
## Summary
- make regex more robust when extracting flow image references

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68813f5b9a348332bca4bfe1f087fbfd