### PR TITLE
Update Gemini model list

### DIFF
--- a/src/components/ConfigurationPanel.jsx
+++ b/src/components/ConfigurationPanel.jsx
@@ -144,8 +144,11 @@ function ConfigurationPanel({ mode = 'full' }) {
                                 <span className="ml-1 text-gray-400" title="Versión del modelo IA">ⓘ</span>
                             </label>
                             <select id="gemini-model-select" value={apiConfig.gemini.model} onChange={(e) => handleConfigChange('gemini', 'model', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm">
-                                <option value="gemini-pro-vision">Gemini Pro Vision</option>
-                                <option value="gemini-pro">Gemini Pro (solo texto)</option>
+                                <option value="gemini-1.5-flash">Gemini&nbsp;1.5&nbsp;Flash</option>
+                                <option value="gemini-2.0-flash">Gemini&nbsp;2.0&nbsp;Flash</option>
+                                <option value="gemini-2.0-flash-lite">Gemini&nbsp;2.0&nbsp;Flash&#8209;Lite</option>
+                                <option value="gemini-2.5-flash">Gemini&nbsp;2.5&nbsp;Flash</option>
+                                <option value="gemini-2.5-flash-lite">Gemini&nbsp;2.5&nbsp;Flash&#8209;Lite</option>
                             </select>
                         </div>
                     </div>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -19,7 +19,7 @@ export const AppProvider = ({ children }) => {
         provider: 'openai',
         openai: { key: '', model: 'gpt-4o' },
         claude: { key: '', model: 'claude-3-sonnet-20240229' },
-        gemini: { key: '', model: 'gemini-pro-vision' }
+        gemini: { key: '', model: 'gemini-1.5-flash' }
     });
     const [currentImageFiles, setCurrentImageFiles] = useState([]);
     const [initialContext, setInitialContext] = useState('');


### PR DESCRIPTION
## Summary
- replace Gemini model dropdown with new Flash and Flash-Lite options
- set default Gemini model to `gemini-1.5-flash`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test:build` *(fails to download dependencies because the environment has no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688579c1745c8332ba406a1968941be1